### PR TITLE
Fix maven_servers parameter passing in scala_repositories

### DIFF
--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -84,7 +84,7 @@ def scala_repositories(
             "io_bazel_rules_scala_scala_xml",
             "io_bazel_rules_scala_scala_parser_combinators",
         ],
-        maven_servers = _default_maven_server_urls(),
+        maven_servers = maven_servers,
         fetch_sources = fetch_sources,
         overriden_artifacts = overriden_artifacts,
     )


### PR DESCRIPTION
### Description
scala_repositories should use the passed parameter value instead of providing _default_maven_server_urls as a value passed downstream.

### Motivation
scala_repositories does not currently work with custom maven_servers attribute as the implementation uses the default anyhow.
This blocks rules_scala if the default maven repositories are unavailable (e.g. in restricted company networks).
